### PR TITLE
Update capability statements and update package version

### DIFF
--- a/CapabilityStatements/capabilitystatement-Immunization-ClientCapabilities.xml
+++ b/CapabilityStatements/capabilitystatement-Immunization-ClientCapabilities.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<CapabilityStatement xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/R4/capabilitystatement.xsd">
+<CapabilityStatement xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <id value="Immunization-ClientCapabilities"/>
   <url value="http://nictiz.nl/fhir/CapabilityStatement/Immunization-ClientCapabilities" />
   <name value="Immunization_Clientcapabilities" />

--- a/CapabilityStatements/capabilitystatement-Immunization-ClientCapabilities.xml
+++ b/CapabilityStatements/capabilitystatement-Immunization-ClientCapabilities.xml
@@ -28,48 +28,49 @@
       <interaction>
         <code value="search-type" />
       </interaction>
-      <searchInclude value="Immunization:medication"/>
+      <searchInclude value="Immunization:patient"/>
+      <searchInclude value="Immunization:performer"/>
     </resource>
     <resource>
       <type value="Patient" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"/>
       <interaction>
-        <code value="search-type" />
+        <code value="read" />
       </interaction>
     </resource>
     <resource>
       <type value="Organization" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization"/>
       <interaction>
-        <code value="search-type" />
+        <code value="read" />
       </interaction>
     </resource>
     <resource>
       <type value="Location" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider"/>
       <interaction>
-        <code value="search-type" />
+        <code value="read" />
       </interaction>
     </resource>
     <resource>
       <type value="Practitioner" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthProfessional-Practitioner"/>
       <interaction>
-        <code value="search-type" />
+        <code value="read" />
       </interaction>
     </resource>
     <resource>
       <type value="PractitionerRole" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthProfessional-PractitionerRole"/>
       <interaction>
-        <code value="search-type" />
+        <code value="read" />
       </interaction>
     </resource>
     <resource>
       <type value="Medication" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-PharmaceuticalProduct"/>
       <interaction>
-        <code value="search-type" />
+        <code value="read" />
       </interaction>
     </resource>
   </rest>

--- a/CapabilityStatements/capabilitystatement-Immunization-ClientCapabilities.xml
+++ b/CapabilityStatements/capabilitystatement-Immunization-ClientCapabilities.xml
@@ -28,8 +28,6 @@
       <interaction>
         <code value="search-type" />
       </interaction>
-      <searchInclude value="Immunization:patient"/>
-      <searchInclude value="Immunization:performer"/>
     </resource>
     <resource>
       <type value="Patient" />

--- a/CapabilityStatements/capabilitystatement-Immunization-ServerCapabilities.xml
+++ b/CapabilityStatements/capabilitystatement-Immunization-ServerCapabilities.xml
@@ -28,49 +28,32 @@
       <interaction>
         <code value="search-type" />
       </interaction>
-      <searchInclude value="Immunization:medication"/>
+      <searchInclude value="Immunization:patient"/>
+      <searchInclude value="Immunization:performer"/>
     </resource>
     <resource>
       <type value="Patient" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"/>
-      <interaction>
-        <code value="read" />
-      </interaction>
     </resource>
     <resource>
       <type value="Organization" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization"/>
-      <interaction>
-        <code value="read" />
-      </interaction>
     </resource>
     <resource>
       <type value="Location" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider"/>
-      <interaction>
-        <code value="read" />
-      </interaction>
     </resource>
     <resource>
       <type value="Practitioner" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthProfessional-Practitioner"/>
-      <interaction>
-        <code value="read" />
-      </interaction>
     </resource>
     <resource>
       <type value="PractitionerRole" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthProfessional-PractitionerRole"/>
-      <interaction>
-        <code value="read" />
-      </interaction>
     </resource>
     <resource>
       <type value="Medication" />
       <supportedProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-PharmaceuticalProduct"/>
-      <interaction>
-        <code value="read" />
-      </interaction>
     </resource>
   </rest>
 </CapabilityStatement>

--- a/CapabilityStatements/capabilitystatement-Immunization-ServerCapabilities.xml
+++ b/CapabilityStatements/capabilitystatement-Immunization-ServerCapabilities.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<CapabilityStatement xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/R4/capabilitystatement.xsd">
+<CapabilityStatement xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <id value="Immunization-ServerCapabilities"/>
   <url value="http://nictiz.nl/fhir/CapabilityStatement/Immunization-ServerCapabilities" />
   <name value="Immunization_Servercapabilities" />

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This repository contains HL7 FHIR R4 compliant profiles and related conformance materials for the information standard [Immunization](https://informatiestandaarden.nictiz.nl/wiki/Immu:V0.1_Ontwerpen).
 
-This repository has a dependency on the [zib2020 package](https://simplifier.net/NictizR4-Zib2020/~packages).
+This repository has a dependency on the [zib2020 package](https://simplifier.net/Nictiz-R4-zib2020/~packages).
 
 This repository is maintained by the Dutch National Intitute for ICT in Healthcare (Nictiz).
 
 ## Official releases
 
-Resources in this repository should be considered unstable and not suited for immediate implementation. Stable versions will be released using the FHIR package mechanism on [Simplifier](https://simplifier.net/packages). At the moment, no package has been released for the current project.
+Resources in this repository should be considered unstable and not suited for immediate implementation. Stable versions will be released using the FHIR package mechanism on [Simplifier](https://simplifier.net/packages). At the moment, no stable package has been released for the current project.
 
 ## Profiling guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nictiz-R4-Immunization
 
-This repository contains HL7 FHIR R4 compliant profiles and related conformance materials for the information standaard [Immunization](https://informatiestandaarden.nictiz.nl/wiki/Immu:V0.1_Ontwerpen).
+This repository contains HL7 FHIR R4 compliant profiles and related conformance materials for the information standard [Immunization](https://informatiestandaarden.nictiz.nl/wiki/Immu:V0.1_Ontwerpen).
 
 This repository has a dependency on the [zib2020 package](https://simplifier.net/NictizR4-Zib2020/~packages).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nictiz.fhir.nl.r4.Immunization",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "canonical": null,
     "url": "https://informatiestandaarden.nictiz.nl/wiki/MedMij:Vdraft/OntwerpVaccinaties",
     "title": "Nictiz FHIR NL R4 Immunization",


### PR DESCRIPTION
Update the capability statements such that the Client can perform a search on de Immunization resource and, if necessary, perform a read for the other supported profiles (which are referenced in the Immunization instance). The Interaction type is removed from the supported profiles (excluding Immunization) of the server capability statements; The server can provide all the supported profiles in the response bundel with the initial request and/or support a 'read' functionality such that the referenced profiles can be obtained separately based on the references. The _include capability has also been updated for both the client and server. The changes needs to be includes a new packages, thus the package version has been updated.